### PR TITLE
Fix: Keep removed traffic lights on big roads after loading a saved game

### DIFF
--- a/Crossings/UpdateNodeFlags.cs
+++ b/Crossings/UpdateNodeFlags.cs
@@ -1,52 +1,31 @@
-using ColossalFramework;
 using HarmonyLib;
-using UnityEngine;
 
 namespace Crossings
 {
-	[HarmonyPatch(typeof(RoadBaseAI))]
+  [HarmonyPatch(typeof(RoadBaseAI))]
 	[HarmonyPatch(nameof(RoadBaseAI.UpdateNodeFlags))]
 	class UpdateNodeFlags
 	{
-		static void Postfix(ref RoadBaseAI __instance, ref NetNode data)
+		static bool Prefix(ref RoadBaseAI __instance, ref NetNode data)
 		{
-			bool wantTrafficLights = __instance.WantTrafficLights();
-			NetManager netManager = Singleton<NetManager>.instance;
+			var andFlags = 
+				Crossings.CrossingFlag 
+				| NetNode.Flags.TrafficLights
+				| NetNode.Flags.CustomTrafficLights
+				;
+			var checkFlags =
+				Crossings.CrossingFlag 
+				| NetNode.Flags.TrafficLights
+				;
 
-			//Debug.Log("isCrossing: " + isCrossing);
-			//Debug.Log("wantTrafficLights: " + wantTrafficLights);
-
-			if (!wantTrafficLights)
+			// Crossing & TrafficLights, but no CustomTrafficLights
+			if((data.m_flags & andFlags) == checkFlags)
 			{
-				for (int i = 0; i < 8; i++)
-				{
-					ushort segment = data.GetSegment(i);
-					if (segment != 0)
-					{
-						NetInfo info = netManager.m_segments.m_buffer[(int)segment].Info;
-						if (info != null)
-						{
-							if ((info.m_vehicleTypes & VehicleInfo.VehicleType.Train) != VehicleInfo.VehicleType.None)
-							{
-								// No crossings allowed where there's a railway intersecting
-								return;
-							}
-
-							if (info.m_netAI.WantTrafficLights())
-							{
-								wantTrafficLights = true;
-							}
-						}
-					}
-				}
+				data.m_flags |= NetNode.Flags.CustomTrafficLights;
 			}
 
-			bool isCrossing = (data.m_flags & (NetNode.Flags)Crossings.CrossingFlag) != NetNode.Flags.None;
-
-			if (wantTrafficLights && isCrossing)
-			{
-				data.m_flags |= NetNode.Flags.TrafficLights;
-			}
+			// return true -> execute UpdateNodeFlags
+			return true;
 		}
 	}
 }


### PR DESCRIPTION
by `--JR--` in Steam Workshop Comments (15 Feb 2022) for Crossings as well as [ToggleTrafficLights](https://steamcommunity.com/sharedfiles/filedetails/?id=411833858)
> It seems now on every saved game load, traffic lights are being added to 4-lane & 6-lane street crossings made by the "crossings" mod even if you have traffic lights disabled... 

`Crossings` updates all Crossings that want a traffic light after loading a saved game (in [`UpdateNodeFlags.cs`](https://github.com/bernardd/Crossings/blob/cea617b9c7829f6b50bf20c40e3717fc34b854c9/Crossings/UpdateNodeFlags.cs)).  
But this overrides removed traffic lights (for example via [`ToggleTrafficLights`](https://steamcommunity.com/sharedfiles/filedetails/?id=411833858)).


This PR changes the current behavior: instead of recalculating Traffic Lights whenever `UpdateNodeFlags` is called (for example after loading a map), it now just initially sets the wanted Traffic Lights when the Crossing is created and never touches it again.  
When Traffic Lights, additional the flag `CustomTrafficLights` is set -> keeps Traffic Lights after savegame load (unless it's changed by someone else).



[`UpdateNodeFlags`](https://github.com/bernardd/Crossings/blob/bde3aea77f7af7cc38ebc50b46b51e1e329d06ea/Crossings/UpdateNodeFlags.cs) (to set TrafficLights on Crossings) isn't used any more -- except for backwards compatibility: Crossings created prior to this patch don't have `CustomTrafficLights` attached.  
-> C:S `RoadBaseAI.UpdateNodeFlags` ignores `TrafficLights` when no `CustomTrafficLights` set and resets it (-> no Traffic Lights any more on crossings on large roads).  
Prior to this PR this mod always recalculated Traffic Lights. That was necessary because no `CustomTrafficLights` was set. New Crossings (with this PR here) get created with `CustomTrafficLights`, but existing ones (prior to this PR) don't have it. But after C:S `UpdateNodeFlags` a custom Traffic Lights is indistinguishable from an auto-created one. 
-> Is now Prefix (instead Postfix), ignores crossings with `CustomTrafficLights`, adds `CustomTrafficLights` to existing crossings with `TrafficLights`

So before this PR on crossing on large road:
* UpdateNodeFlags -> sees `TrafficLights` without `CustomTrafficLights` -> resets state -> removes `TrafficLights`
* Postfix -> sees `Crossing` -> `TrafficLights`

With PR:
* Prefix: sees `Crossing` with `TrafficLights` -> adds `CustomTrafficLights`
* UpdateNodeFlags -> sees `TrafficLights` with `CustomTrafficLights` -> keeps `TrafficLights`


I think I got this backward-compatibility-stuff right. But test it before releasing! I stumbled over to many strange things when some flag does get reset and when it doesn't.